### PR TITLE
Remove Washington Post

### DIFF
--- a/app/src/main/res/xml/pref_debug.xml
+++ b/app/src/main/res/xml/pref_debug.xml
@@ -26,10 +26,6 @@
       android:summary="http://forward.immobilienscout24.de/9004STF/expose/78069302"/>
 
     <Preference
-      android:title="Washington Post"
-      android:summary="https://www.washingtonpost.com/nation/2021/12/30/colorado-grass-fire/"/>
-
-    <Preference
       android:title="Non-Http url"
       android:summary="is24://retargetShowSearchForm"/>
 

--- a/redirect/src/main/kotlin/com/tasomaniac/openwith/redirect/UrlFix.kt
+++ b/redirect/src/main/kotlin/com/tasomaniac/openwith/redirect/UrlFix.kt
@@ -148,14 +148,6 @@ class UrlFix @Inject constructor(
         }
     }
 
-    private class WashingtonPostFixer : Fixer {
-        override fun fix(url: String): String {
-            return url
-                .replace("http://www.washingtonpost.com", "wp-android://www.washingtonpost.com")
-                .replace("https://www.washingtonpost.com", "wp-android://www.washingtonpost.com")
-        }
-    }
-
     companion object {
         private val URL_FIXERS = setOf(
             FacebookFixer(),
@@ -163,8 +155,7 @@ class UrlFix @Inject constructor(
             EbayFixer(),
             AmazonFixer(),
             DailyMailFixer(),
-            VkFixer(),
-            WashingtonPostFixer()
+            VkFixer()
         )
     }
 }


### PR DESCRIPTION
When the app isn't installed, this code leads to the inability to open the links.